### PR TITLE
Add 'Mount' (analog to 'Capture', etc.)

### DIFF
--- a/servant/example/greet.hs
+++ b/servant/example/greet.hs
@@ -50,9 +50,9 @@ instance ToSample Greet where
 
 -- API specification
 type TestApi = 
-       "hello" :> Capture "name" Text :> GetParam "capital" Bool :> Get Greet
-  :<|> "greet" :> RQBody Greet :> Post Greet
-  :<|> "delete" :> Capture "greetid" Text :> Delete
+       Mount "hello" :> Capture "name" Text :> GetParam "capital" Bool :> Get Greet
+  :<|> Mount "greet" :> RQBody Greet :> Post Greet
+  :<|> Mount "delete" :> Capture "greetid" Text :> Delete
 
 testApi :: Proxy TestApi
 testApi = Proxy

--- a/servant/servant.cabal
+++ b/servant/servant.cabal
@@ -24,6 +24,7 @@ library
     Servant.API.Delete
     Servant.API.Get
     Servant.API.GetParam
+    Servant.API.Mount
     Servant.API.Post
     Servant.API.Put
     Servant.API.Raw

--- a/servant/src/Servant/API.hs
+++ b/servant/src/Servant/API.hs
@@ -7,6 +7,8 @@ module Servant.API (
   module Servant.API.Union,
 
   -- * Accessing information from the request
+  -- | Routing based on 'Network.Wai.pathInfo' snippets
+  module Servant.API.Mount,
   -- | Capturing parts of the url path as parsed values
   module Servant.API.Capture,
   -- | Retrieving parameters from the query part of the 'URI'
@@ -29,6 +31,7 @@ import Servant.API.Capture
 import Servant.API.Delete
 import Servant.API.Get
 import Servant.API.GetParam
+import Servant.API.Mount
 import Servant.API.Post
 import Servant.API.Put
 import Servant.API.RQBody

--- a/servant/src/Servant/API/Mount.hs
+++ b/servant/src/Servant/API/Mount.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Servant.API.Mount where
+
+import Data.Proxy
+import Data.String.Conversions
+import GHC.TypeLits
+import Network.Wai
+import Servant.Client
+import Servant.Docs
+import Servant.Server
+import Servant.API.Sub
+
+data Mount path
+
+instance (KnownSymbol path, HasServer sublayout) => HasServer (Mount path :> sublayout) where
+  type Server (Mount path :> sublayout) = Server sublayout
+  route Proxy subserver request respond = case pathInfo request of
+    (first : rest)
+      | first == cs (symbolVal proxyPath)
+      -> route (Proxy :: Proxy sublayout) subserver request{
+           pathInfo = rest
+         } respond
+    _ -> respond Nothing
+
+    where proxyPath = Proxy :: Proxy path
+
+instance (KnownSymbol path, HasClient sublayout) => HasClient (Mount path :> sublayout) where
+  type Client (Mount path :> sublayout) = Client sublayout
+
+  clientWithRoute Proxy req =
+     clientWithRoute (Proxy :: Proxy sublayout) $
+       appendToPath p req
+
+    where p = symbolVal (Proxy :: Proxy path)
+
+instance (KnownSymbol path, HasDocs sublayout) => HasDocs (Mount path :> sublayout) where
+
+  docsFor Proxy (endpoint, action) =
+    docsFor sublayoutP (endpoint', action)
+
+    where sublayoutP = Proxy :: Proxy sublayout
+          endpoint' = endpoint & path <>~ symbolVal pa
+          pa = Proxy :: Proxy path

--- a/servant/src/Servant/API/Sub.hs
+++ b/servant/src/Servant/API/Sub.hs
@@ -5,44 +5,8 @@
 module Servant.API.Sub where
 
 import Data.Proxy
-import Data.String.Conversions
-import GHC.TypeLits
-import Network.Wai
-import Servant.Client
-import Servant.Docs
-import Servant.Server
 
 -- | The contained API (second argument) can be found under @("/" ++ path)@
 -- (path being the first argument).
 data (path :: k) :> a = Proxy path :> a
 infixr 9 :>
-
-instance (KnownSymbol path, HasServer sublayout) => HasServer (path :> sublayout) where
-  type Server (path :> sublayout) = Server sublayout
-  route Proxy subserver request respond = case pathInfo request of
-    (first : rest)
-      | first == cs (symbolVal proxyPath)
-      -> route (Proxy :: Proxy sublayout) subserver request{
-           pathInfo = rest
-         } respond
-    _ -> respond Nothing
-
-    where proxyPath = Proxy :: Proxy path
-
-instance (KnownSymbol path, HasClient sublayout) => HasClient (path :> sublayout) where
-  type Client (path :> sublayout) = Client sublayout
-
-  clientWithRoute Proxy req =
-     clientWithRoute (Proxy :: Proxy sublayout) $
-       appendToPath p req
-
-    where p = symbolVal (Proxy :: Proxy path)
-
-instance (KnownSymbol path, HasDocs sublayout) => HasDocs (path :> sublayout) where
-
-  docsFor Proxy (endpoint, action) =
-    docsFor sublayoutP (endpoint', action)
-
-    where sublayoutP = Proxy :: Proxy sublayout
-          endpoint' = endpoint & path <>~ symbolVal pa
-          pa = Proxy :: Proxy path

--- a/servant/test/Servant/ServerSpec.hs
+++ b/servant/test/Servant/ServerSpec.hs
@@ -23,6 +23,7 @@ import Test.Hspec.Wai
 import Servant.API.Capture
 import Servant.API.Get
 import Servant.API.GetParam
+import Servant.API.Mount
 import Servant.API.Post
 import Servant.API.Raw
 import Servant.API.RQBody
@@ -155,7 +156,7 @@ postSpec = do
          }
 
 
-type RawApi = "foo" :> Raw
+type RawApi = Mount "foo" :> Raw
 rawApi :: Proxy RawApi
 rawApi = Proxy
 rawApplication :: Show a => (Request -> a) -> Application
@@ -182,8 +183,8 @@ rawSpec = do
 
 
 type UnionApi =
-       "foo" :> Get Person
-  :<|> "bar" :> Get Animal
+       Mount "foo" :> Get Person
+  :<|> Mount "bar" :> Get Animal
 unionApi :: Proxy UnionApi
 unionApi = Proxy
 


### PR DESCRIPTION
I'm not sure if I find this better than before, but it's a bit more consistent. `Mount` then works in the same way that `Capture`, `RQBody`, etc. work. I.e. `:>` doesn't treat mounting special.

@alpmestan, @jkarni: What do you think?
