### PR TITLE
More query params

### DIFF
--- a/servant/example/greet.hs
+++ b/servant/example/greet.hs
@@ -43,6 +43,7 @@ instance ToParam (QueryParam "capital" Bool) where
     DocQueryParam "capital"
                   ["true", "false"]
                   "Get the greeting message in uppercase (true) or not (false). Default is false."
+                  Normal
 
 instance ToSample Greet where
   toSample Proxy = Just (encode g)

--- a/servant/src/Servant/API/QueryParam.hs
+++ b/servant/src/Servant/API/QueryParam.hs
@@ -110,6 +110,16 @@ instance (KnownSymbol sym, ToText a, HasClient sublayout)
           pname' = symbolVal (Proxy :: Proxy sym)
           paramlist' = map (Just . toText) paramlist
 
+instance (KnownSymbol sym, ToParam (QueryParams sym a), HasDocs sublayout)
+      => HasDocs (QueryParams sym a :> sublayout) where
+
+  docsFor Proxy (endpoint, action) =
+    docsFor sublayoutP (endpoint, action')
+
+    where sublayoutP = Proxy :: Proxy sublayout
+          paramP = Proxy :: Proxy (QueryParams sym a)
+          action' = over params (|> toParam paramP) action
+
 -- | Retrieve a value-less boolean from the query string.
 data QueryFlag a
 
@@ -142,3 +152,13 @@ instance (KnownSymbol sym, HasClient sublayout)
         else req
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
+
+instance (KnownSymbol sym, ToParam (QueryFlag sym), HasDocs sublayout)
+      => HasDocs (QueryFlag sym :> sublayout) where
+
+  docsFor Proxy (endpoint, action) =
+    docsFor sublayoutP (endpoint, action')
+
+    where sublayoutP = Proxy :: Proxy sublayout
+          paramP = Proxy :: Proxy (QueryFlag sym)
+          action' = over params (|> toParam paramP) action

--- a/servant/src/Servant/Client.hs
+++ b/servant/src/Servant/Client.hs
@@ -39,10 +39,9 @@ appendToQueryString :: Text       -- ^ param name
                     -> Maybe Text -- ^ param value
                     -> Req
                     -> Req
-appendToQueryString pname pvalue req
-  | pvalue == Nothing = req
-  | otherwise         = req { qs = qs req ++ [(pname, pvalue)]
-                            }
+appendToQueryString pname pvalue req =
+  req { qs = qs req ++ [(pname, pvalue)]
+      }
 
 setRQBody :: ByteString -> Req -> Req
 setRQBody b req = req { reqBody = b }


### PR DESCRIPTION
This addresses #19 and also adds a `QueryFlag` param for value-less GET parameters. Comes with server, client & docs support, along with some tests.
